### PR TITLE
RP server handling

### DIFF
--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -55,6 +55,7 @@ sub sysread {
 		my $request = HTTP::Request->new( GET => $v->{'url'} ); 
 		$request->header( 'Range', "bytes=$v->{'offset'}-" );
 		$v->{'session'} = Slim::Networking::Async::HTTP->new;
+		$v->{'lastSeen'} = undef;
 			
 		main::DEBUGLOG && $log->is_debug && $log->debug("streaming from $v->{'offset'} for $v->{'url'}");
 	

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -55,7 +55,6 @@ sub close {
 	$v->{'status'} = IDLE;
 	$v->{'offset'} = 0;
 	$self->SUPER::close();
-	$log->error("closing $v->{'url'}");
 }
 
 sub sysread {
@@ -72,8 +71,7 @@ sub sysread {
 		$v->{'lastSeen'} = undef;
 			
 		main::DEBUGLOG && $log->is_debug && $log->debug("streaming from $v->{'offset'} for $v->{'url'}");
-		$log->error("streaming from $v->{'offset'} for $v->{'url'}");
-	
+			
 		$v->{'session'}->send_request( {
 			request     => $request,
 			onHeaders => sub {
@@ -84,7 +82,6 @@ sub sysread {
 				$v->{'song'}->bitrate($v->{'length'} * 8 / getBlockData(undef, $v->{'song'})->{length}) if $v->{'length'};
 				Slim::Control::Request::notifyFromArray( $v->{'song'}->master, [ 'newmetadata' ] );
 				main::INFOLOG && $log->is_info && $log->info("length ", $v->{'length'} || 0, " setting bitrate ", int ($v->{'song'}->bitrate), " for $v->{'url'}");
-				$log->error("length ", $v->{'length'} || 0, " setting bitrate ", int ($v->{'song'}->bitrate), " for $v->{'url'}");
 			},	
 			onError  => sub { 
 				$v->{'session'}->disconnect;
@@ -111,7 +108,6 @@ sub sysread {
 	} elsif ( !$v->{'length'} || $v->{'offset'} == $v->{'length'} || $v->{'errors'} >= MAX_ERRORS ) {
 		$v->{'session'}->disconnect;
 		main::INFOLOG && $log->is_info && $log->info("end of $v->{'url'} s:", time() - $v->{'lastSeen'}, " e:$v->{'errors'} c:$!");
-		$log->error("end of $v->{'url'} $!");
 		return 0;
 	} else {
 		$log->warn("unexpected connection close at $v->{'offset'}/$v->{'length'} (since ", time() - $v->{'lastSeen'}, ") for $v->{'url'} $_! ");

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -13,7 +13,6 @@ use Slim::Utils::Log;
 use Slim::Utils::Prefs;
 use Slim::Utils::Timers;
 use Slim::Utils::Errno;
-use Slim::Networking::Async::HTTP;
 
 use Plugins::RadioParadise::Stations;
 

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -104,7 +104,7 @@ sub sysread {
 		$v->{'offset'} += $bytes;
 		$v->{'lastSeen'} = time();
 		return $bytes;
-	} elsif ( !defined $bytes && $v->{'errors'} < MAX_ERRORS && ($v->{'status'} != CONNECTED || $! == EINTR || $! == EWOULDBLOCK) && (!defined $v->{'lastSeen'} || $v->{'lastSeen'} - time() < 10) ){
+	} elsif ( !defined $bytes && $v->{'errors'} < MAX_ERRORS && ($v->{'status'} != CONNECTED || $! == EINTR || $! == EWOULDBLOCK) && (!defined $v->{'lastSeen'} || time() - $v->{'lastSeen'} < 5) ){
 		$! = EINTR;
 		main::DEBUGLOG && $log->is_debug && $log->debug("need to wait for $v->{'url'}");
 		return undef;

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -110,11 +110,11 @@ sub sysread {
 		return undef;
 	} elsif ( !$v->{'length'} || $v->{'offset'} == $v->{'length'} || $v->{'errors'} >= MAX_ERRORS ) {
 		$v->{'session'}->disconnect;
-		main::INFOLOG && $log->is_info && $log->info("end of $v->{'url'} s:", $v->{'lastSeen'} - time(), " e:$v->{'errors'} c:$!");
+		main::INFOLOG && $log->is_info && $log->info("end of $v->{'url'} s:", time() - $v->{'lastSeen'}, " e:$v->{'errors'} c:$!");
 		$log->error("end of $v->{'url'} $!");
 		return 0;
 	} else {
-		$log->warn("unexpected connection close at $v->{'offset'}/$v->{'length'} (since ", $v->{'lastSeen'} - time(), ") for $v->{'url'} $_! ");
+		$log->warn("unexpected connection close at $v->{'offset'}/$v->{'length'} (since ", time() - $v->{'lastSeen'}, ") for $v->{'url'} $_! ");
 		$v->{'session'}->disconnect;
 		$v->{'status'} = IDLE;
 		$v->{'errors'}++;

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -287,10 +287,7 @@ sub getMetadataFor {
 
 		if ($url) {
 			my $bitrate = int($song->bitrate ? ($song->bitrate / 1024) : 850) . 'k VBR FLAC';
-
-			#if (main::INFOLOG && $log->is_info) {
-				$bitrate .=  sprintf(" (%u/%u - %u:%02u)", $index + 1, scalar(keys %{$cached->{song}}), $cached->{length}/60, int($cached->{length} % 60));
-			#}
+			$bitrate .=  sprintf(" (%u/%u - %u:%02u)", $index + 1, scalar(keys %{$cached->{song}}), $cached->{length}/60, int($cached->{length} % 60));
 
 			$meta = {
 				artist => $songdata->{artist},


### PR DESCRIPTION
This is to try to fix the RP stream interruption that seems to happen with interactive streams.

For that, I had to change the subclassing to a simple IO::Handle and manage "manually" sysread by reading the block in smaller chunks in a persistent connection and it that connection fails, restart from where we were left. 

It's a lot of changes, I'm sorry but I don't know how to do otherwise. I'm submitting early so that we can discuss it, but it's not yet finalized especially I'm missing the possibility to efficienctly rotate across servers when one is failing.