### PR TITLE
Allow for gain equalization of FLAC streams.

### DIFF
--- a/HTML/EN/plugins/RadioParadise/settings.html
+++ b/HTML/EN/plugins/RadioParadise/settings.html
@@ -15,6 +15,10 @@
 		[% END %]
 	[% END %]
 
+	[% WRAPPER settingGroup title="PLUGIN_RADIO_PARADISE_REPLAYGAIN" desc="PLUGIN_RADIO_PARADISE_REPLAYGAIN_DESC" %]
+		<input type="text" class="stdedit sliderInput_-10_10_0.1" name="pref_replayGain" id="replayGain" value="[% prefs.pref_replayGain | html %]" size="5">
+	[% END %]
+
 	[% WRAPPER setting title="PLUGIN_RADIO_PARADISE_MENULOCATION" desc="PLUGIN_RADIO_PARADISE_MENULOCATION_DESC" %]
 		<div>
 			<select class="stdedit" name="pref_showInRadioMenu" id="showInRadioMenu">

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -41,6 +41,10 @@ if ($canLossless) {
 	$canLossless = 0 if $@;
 }
 
+$prefs->init({
+	replayGain => 0
+});
+
 # s13606 is the TuneIn ID for RP - Shoutcast URLs are recognized by the cover URL. Hopefully.
 #my $radioUrlRegex = qr/(?:\.radioparadise\.com|id=s13606|shoutcast\.com.*id=(785339|101265|1595911|674983|308768|1604072|1646896|1695633|856611))/i;
 my $radioUrlRegex = qr/(?:^radioparadise:|\.radioparadise\.com|id=s13606|radio_paradise)/i;

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -42,6 +42,7 @@ if ($canLossless) {
 }
 
 $prefs->init({
+	showInRadioMenu => 0,
 	replayGain => 0
 });
 

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -390,11 +390,12 @@ sub trackGain {
 	my ( $class, $client, $url ) = @_;
 
 	main::DEBUGLOG && $log->is_debug && $log->debug("Url: $url");
-
- 	my $rgmode = preferences('server')->client($client)->get('replayGainMode');  # is replay gain in effect?
-	my $remoteGain = preferences('server')->client($client)->get('remoteReplayGain');
 	
-	return $rgmode ? $remoteGain + $prefs->get('replayGain') : undef;
+	my $cPrefs = preferences('server')->client($client);  # access player prefs
+ 	my $rgmode = $cPrefs->get('replayGainMode');  # is player replay gain in effect?
+	
+	# if so, return the sum of remoteReplayGain and the plugin's adjustment	
+	return $rgmode ? $cPrefs->get('remoteReplayGain') + $prefs->get('replayGain') : undef;
 }
 
 1;

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -385,4 +385,16 @@ sub getIcon {
 	return Plugins::RadioParadise::Plugin->_pluginDataFor('icon');
 }
 
+# Optionally override replaygain to use the plugin's gain value
+sub trackGain {
+	my ( $class, $client, $url ) = @_;
+
+	main::DEBUGLOG && $log->is_debug && $log->debug("Url: $url");
+
+ 	my $rgmode = preferences('server')->client($client)->get('replayGainMode');  # is replay gain in effect?
+	my $remoteGain = preferences('server')->client($client)->get('remoteReplayGain');
+	
+	return $rgmode ? $remoteGain + $prefs->get('replayGain') : undef;
+}
+
 1;

--- a/Settings.pm
+++ b/Settings.pm
@@ -20,7 +20,7 @@ sub page {
 }
 
 sub prefs {
-	return ($prefs, qw(showInRadioMenu));
+	return ($prefs, qw(showInRadioMenu replayGain));
 }
 
 sub handler {

--- a/strings.txt
+++ b/strings.txt
@@ -185,3 +185,13 @@ PLUGIN_RADIO_PARADISE_MENULOCATION_DESC
 	DE	Wählen Sie, ob das Plugin in "Eigene Anwendungen" oder "Radio" auftauchen soll. Bitte beachten Sie, dass Sie den Server neu starten müssen, um die Änderung zu aktivieren.
 	EN	Select if you want the plugin to appear in "My Apps" or "Radio". Note that you will need to restart the server after changing this setting.
 	FR	Sélectionnez si vous souhaitez que le plugin apparaisse dans le menu "Mes applications" ou "Radio". Notez que vous devrez redémarrer le serveur après avoir modifié ce paramètre.
+
+PLUGIN_RADIO_PARADISE_REPLAYGAIN
+	DE	Lautstärkeregelung
+	EN	Volume adjustment
+	FR	Réglage du volume
+
+PLUGIN_RADIO_PARADISE_REPLAYGAIN_DESC
+	DE	Zusätzlicher Betrag der Lautstärkeanpassung, der nach der „Anpassung für Internet-Streams“ angewendet werden soll (nur FLAC Interactive-Streams).
+	EN	Additional amount of volume adjustment to be applied after the "Default Adjustment for Remote Streams" (FLAC Interactive streams only).
+	FR	Quantité supplémentaire d'ajustement du volume à appliquer après le "Ajustement du volume pour le streaming Internet" (flux FLAC Interactive uniquement).


### PR DESCRIPTION
Some users report that the gain of Radio Paradise streams can vary significantly from other streaming sources. This change allows the gain to be adjusted up to +/- 10dB relative to other streams for FLAC Interactive streams only.