### PR TITLE
Fix errors in metadata retrieval.

### DIFF
--- a/MetadataProvider.pm
+++ b/MetadataProvider.pm
@@ -200,7 +200,7 @@ sub _gotMetadataError {
 sub _fixHDMetadata {
 	my ($client, $url, $meta) = @_;
 
-	if ( $client->pluginData('rpHD') && (my $hdImage = $cache->get( "remote_image_$url")) ) {
+	if ( defined $client && $client->pluginData('rpHD') && (my $hdImage = $cache->get( "remote_image_$url")) ) {
 		main::DEBUGLOG && $log->is_debug && $log->debug("Replacing artwork with HD image: $hdImage");
 		$meta = Storable::dclone($meta);
 		$meta->{cover} = $meta->{icon} = $hdImage;

--- a/MetadataProvider.pm
+++ b/MetadataProvider.pm
@@ -200,7 +200,7 @@ sub _gotMetadataError {
 sub _fixHDMetadata {
 	my ($client, $url, $meta) = @_;
 
-	if ( defined $client && $client->pluginData('rpHD') && (my $hdImage = $cache->get( "remote_image_$url")) ) {
+	if ( $client && $client->pluginData('rpHD') && (my $hdImage = $cache->get( "remote_image_$url")) ) {
 		main::DEBUGLOG && $log->is_debug && $log->debug("Replacing artwork with HD image: $hdImage");
 		$meta = Storable::dclone($meta);
 		$meta->{cover} = $meta->{icon} = $hdImage;

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -144,6 +144,8 @@ sub getNextTrack {
 sub getMetadataFor {
 	my ( $class, $client, $url, undef, $song ) = @_;
 
+	return {} unless $client;
+
 	$client = $client->master;
 	$song ||= $client->playingSong();
 	return {} unless $song;


### PR DESCRIPTION
getMetadataFor() does not check for a valid $client when called. This causes lyrics retrieval to fail when called from the MAI plugin for Interactive FLAC streams.

Also prevent errors attempting to populate default metadata artwork when $client is not present.